### PR TITLE
for non-batched KZG scheme, fix typo in powers of gamma for F and v

### DIFF
--- a/PLONK.tex
+++ b/PLONK.tex
@@ -892,7 +892,7 @@ We describe the following scheme based on \cite{kate,sonic}.
  and using \srs0 computes and sends $W\defeq \enc1{h(x)}$.
 % \[]
  \item\label{step:computeW} \verpc computes the elements 
- \[F\defeq \sum_{i\in [t]} \gamma^{i} \cdot \cm_i, v\defeq \enc1{\sum_{i\in [t]} \gamma^{i}\cdot s_i}\]
+ \[F\defeq \sum_{i\in [t]} \gamma^{i-1} \cdot \cm_i, v\defeq \enc1{\sum_{i\in [t]} \gamma^{i-1}\cdot s_i}\]
  \item \verpc outputs \acc if and only if
  \[ e(F-v,\enc2{1})\cdot e(-W,\enc2{x-z} )=1. \]
  \end{enumerate}


### PR DESCRIPTION
I was calculating the result of the pairing function on paper, and there was always a gamma term left over. Then I noticed in the next section for the batched version the power of gamma is i - 1 which actually works. So I assume this is a typo in the paper.